### PR TITLE
Avoid swallowing exceptions; log stack traces

### DIFF
--- a/lambdas/cogify/handler.py
+++ b/lambdas/cogify/handler.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 import requests
+import traceback
 
 import boto3
 
@@ -43,8 +44,8 @@ def upload_file(outfilename, collection):
         return f"s3://{output_bucket}/{collection}/{filename}"
     except Exception as e:
         print("Failed to copy to S3 bucket")
-        print(e)
-        return None
+        traceback.print_exception(e)
+        raise e
 
 
 def download_file(file_uri: str):

--- a/lambdas/data-transfer/handler.py
+++ b/lambdas/data-transfer/handler.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 
 import boto3
 from botocore.errorfactory import ClientError
@@ -47,13 +48,18 @@ def handler(event, context):
         # Check if the corresponding object exists in the target bucket
         try:
             target_s3.head_object(Bucket=TARGET_BUCKET, Key=target_key)
-        except ClientError:
-            # Not found
-            source_s3.download_file(bucket, f"{path}/{name}", tmp_filename)
-            target_s3.upload_file(tmp_filename, TARGET_BUCKET, target_key)
-            # Clean up the data
-            if os.path.exists(tmp_filename):
-                os.remove(tmp_filename)
+        except ClientError as ce:
+            try:
+                # Not found
+                source_s3.download_file(bucket, f"{path}/{name}", tmp_filename)
+                target_s3.upload_file(tmp_filename, TARGET_BUCKET, target_key)
+                # Clean up the data
+                if os.path.exists(tmp_filename):
+                    os.remove(tmp_filename)
+            except Exception as internal_exception:
+                print(f"Failed while trying to upload missing file at s3://{bucket}/{target_key}.")
+                traceback.print_exception(ce)
+                raise Exception(ce, internal_exception)
 
         object["data_url"] = target_url
 

--- a/lambdas/s3-discovery/handler.py
+++ b/lambdas/s3-discovery/handler.py
@@ -1,5 +1,6 @@
 import os
 import re
+import traceback
 
 import boto3
 
@@ -38,8 +39,9 @@ def list_bucket(bucket, prefix, filename_regex):
         return files
 
     except Exception as e:
-        print(e)
-        return e
+        print("Failed during s3 item/asset discovery")
+        traceback.print_exception(e)
+        raise e
 
 
 def handler(event, context):

--- a/lambdas/submit-stac/handler.py
+++ b/lambdas/submit-stac/handler.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import json
 import os
 from urllib.parse import urlparse
+import traceback
 from typing import Any, Dict, Optional, TypedDict, Union
 
 import boto3
@@ -72,9 +73,10 @@ class IngestionApi:
         )
         try:
             response.raise_for_status()
-        except Exception:
+        except Exception as e:
             print(response.text)
-            raise
+            traceback.print_exception(e)
+            raise e
         return response.json()
 
     def submit(self, stac_item: Dict[str, Any]):
@@ -86,9 +88,10 @@ class IngestionApi:
 
         try:
             response.raise_for_status()
-        except:
+        except Exception as e:
             print(response.text)
-            raise
+            traceback.print_exception(e)
+            raise e
 
         return response.json()
 

--- a/scripts/collection.py
+++ b/scripts/collection.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 
 from pypgstac.load import Loader, Methods
 from pypgstac.db import PgstacDB
@@ -29,6 +30,7 @@ def get_dsn_string(secret: dict, localhost: bool = False) -> str:
         return f"postgres://{secret['username']}:{secret['password']}@{host}:{port}/{secret.get('dbname', 'postgis')}"
 
     except Exception as e:
+        traceback.print_exception(e)
         raise e
 
 
@@ -50,7 +52,9 @@ def insert_collections(files):
             insert_collection(file)
             print("Inserted")
         except Exception as e:
-            print("Error inserting collection.", str(e))
+            print("Error inserting collection.")
+            traceback.print_exception(e)
+            raise e
 
 
 @args_handler


### PR DESCRIPTION
This PR aims to make debugging a bit smoother by not swallowing or returning exceptions, as this can lead to downstream errors which are difficult to understand. In particular, during the discovery step, it is possible for permissions issues to cause a `ClientError` which is currently returned rather than raised. This is problematic, as the process continues and ultimately falls over when trying to iterate on said `ClientError` object (a list is expected).

Here's what that error looks like currently:
```json
{
  "errorMessage": "'ClientError' object is not iterable",
  "errorType": "TypeError",
  "requestId": "2470348c-0392-4372-bc39-ddf3618760ba",
  "stackTrace": [
    "  File \"/app/handler.py\", line 54, in handler\n    for filename in filenames:\n"
  ]
}
```