### PR TITLE
Provide all arguments needed for traceback printing prior to python 3.10

### DIFF
--- a/lambdas/cogify/handler.py
+++ b/lambdas/cogify/handler.py
@@ -44,7 +44,7 @@ def upload_file(outfilename, collection):
         return f"s3://{output_bucket}/{collection}/{filename}"
     except Exception as e:
         print("Failed to copy to S3 bucket")
-        traceback.print_exception(e)
+        traceback.print_exception(type(e), e, e.__traceback__)
         raise e
 
 

--- a/lambdas/data-transfer/handler.py
+++ b/lambdas/data-transfer/handler.py
@@ -58,7 +58,7 @@ def handler(event, context):
                     os.remove(tmp_filename)
             except Exception as internal_exception:
                 print(f"Failed while trying to upload missing file at s3://{bucket}/{target_key}.")
-                traceback.print_exception(ce)
+                traceback.print_exception(type(ce), ce, ce.__traceback__)
                 raise Exception(ce, internal_exception)
 
         object["s3_filename"] = target_url

--- a/lambdas/s3-discovery/handler.py
+++ b/lambdas/s3-discovery/handler.py
@@ -40,7 +40,7 @@ def list_bucket(bucket, prefix, filename_regex):
 
     except Exception as e:
         print("Failed during s3 item/asset discovery")
-        traceback.print_exception(e)
+        traceback.print_exception(type(e), e, e.__traceback__)
         raise e
 
 

--- a/lambdas/submit-stac/handler.py
+++ b/lambdas/submit-stac/handler.py
@@ -75,7 +75,7 @@ class IngestionApi:
             response.raise_for_status()
         except Exception as e:
             print(response.text)
-            traceback.print_exception(e)
+            traceback.print_exception(type(e), e, e.__traceback__)
             raise e
         return response.json()
 
@@ -90,7 +90,7 @@ class IngestionApi:
             response.raise_for_status()
         except Exception as e:
             print(response.text)
-            traceback.print_exception(e)
+            traceback.print_exception(type(e), e, e.__traceback__)
             raise e
 
         return response.json()

--- a/scripts/collection.py
+++ b/scripts/collection.py
@@ -30,7 +30,7 @@ def get_dsn_string(secret: dict, localhost: bool = False) -> str:
         return f"postgres://{secret['username']}:{secret['password']}@{host}:{port}/{secret.get('dbname', 'postgis')}"
 
     except Exception as e:
-        traceback.print_exception(e)
+        traceback.print_exception(type(e), e, e.__traceback__)
         raise e
 
 
@@ -53,7 +53,7 @@ def insert_collections(files):
             print("Inserted")
         except Exception as e:
             print("Error inserting collection.")
-            traceback.print_exception(e)
+            traceback.print_exception(type(e), e, e.__traceback__)
             raise e
 
 


### PR DESCRIPTION
This PR fixes an oversight from the previous logging improvement PR. Namely: using the appropriate syntax for `traceback.print_exception` for python <3.10. The syntax is notably clumsy in comparison, but this should get tracebacks in our logs