### PR TITLE
Deploy via GH actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,3 +33,29 @@ jobs:
     uses: ./.github/workflows/test_python_lambda.yml
     with:
       path_to_lambda: lambdas/data-transfer
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy to staging environment
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deploy_env: stage
+      cognito_app_secret: veda-auth-stack-alukach/veda-workflows
+      app_name: veda-data-pipelines
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  deploy:
+    name: Deploy to dev environment
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deploy_env: dev
+      cognito_app_secret: veda-auth-stack-alukach/veda-workflows
+      app_name: veda-data-pipelines

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,29 +33,3 @@ jobs:
     uses: ./.github/workflows/test_python_lambda.yml
     with:
       path_to_lambda: lambdas/data-transfer
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  deploy:
-    name: Deploy to staging environment
-    uses: ./.github/workflows/deploy.yml
-    with:
-      deploy_env: stage
-      cognito_app_secret: veda-auth-stack-alukach/veda-workflows
-      app_name: veda-data-pipelines
-
-on:
-  push:
-    branches: [develop]
-
-jobs:
-  deploy:
-    name: Deploy to dev environment
-    uses: ./.github/workflows/deploy.yml
-    with:
-      deploy_env: dev
-      cognito_app_secret: veda-auth-stack-alukach/veda-workflows
-      app_name: veda-data-pipelines

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      cognito_app_secret:
+        required: true
+        type: string
+      app_name:
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Install Poetry
+        env:
+          POETRY_VIRTUALENVS_CREATE: false
+      - run: |
+          pip install -U pip
+          pip install poetry
+          poetry install
+
+      - name: Install node and related deps
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 17.3.0
+      - run: npm install -g aws-cdk
+
+      - name: Configure awscli
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: deploy
+        env:
+          ENV: ${{ inputs.environment }}
+          COGNITO_APP_SECRET: ${{ inputs.cognito_app_secret }}
+          APP_NAME: ${{ inputs.app_name }}
+      - run: poetry run deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,16 +4,26 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
       cognito_app_secret:
         required: true
-        type: string
+      stac_ingestor_url:
+        required: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.deploy_env }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
+
+      - name: Install poetry
+        run: pipx install poetry
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -22,14 +32,6 @@ jobs:
           cache: 'poetry'
           cache-dependency-path: |
             poetry.lock
-
-      - name: Install Poetry
-        run: |
-          pip install -U pip
-          pip install poetry
-          poetry install
-        env:
-          POETRY_VIRTUALENVS_CREATE: false
 
       - name: Install node and related deps
         uses: actions/setup-node@v3
@@ -46,15 +48,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
-      - name: Store ENV from AWS SecretManager
-        uses: say8425/aws-secrets-manager-actions@v2
-        with:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-west-2
-          SECRET_NAME: ${{ input.cognito_app_secret }}
-
       - name: deploy
         run: poetry run deploy
         env:
           ENV: ${{ inputs.environment }}
+          COGNITO_APP_SECRET: ${{ secrets.COGNITO_APP_SECRET }}
+          STAC_INGESTOR_URL: ${{ secrets.STAC_INGESTOR_URL }}
+          APP_NAME: "veda-data-pipelines"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,35 +7,37 @@ on:
       cognito_app_secret:
         required: true
         type: string
-      app_name:
-        required: true
-        type: string
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Set up Python
-      - uses: actions/setup-python@v4
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
+          cache: 'poetry'
+          cache-dependency-path: |
+            poetry.lock
 
       - name: Install Poetry
-        env:
-          POETRY_VIRTUALENVS_CREATE: false
-      - run: |
+        run: |
           pip install -U pip
           pip install poetry
           poetry install
+        env:
+          POETRY_VIRTUALENVS_CREATE: false
 
       - name: Install node and related deps
-      - uses: actions/setup-node@v3
+        uses: actions/setup-node@v3
         with:
           node-version: 17.3.0
-      - run: npm install -g aws-cdk
+
+      - name: Install AWS CDK
+        run: npm install -g aws-cdk
 
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v1
@@ -44,9 +46,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
+      - name: Store ENV from AWS SecretManager
+        uses: say8425/aws-secrets-manager-actions@v2
+        with:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-west-2
+          SECRET_NAME: ${{ input.cognito_app_secret }}
+
       - name: deploy
+        run: poetry run deploy
         env:
           ENV: ${{ inputs.environment }}
-          COGNITO_APP_SECRET: ${{ inputs.cognito_app_secret }}
-          APP_NAME: ${{ inputs.app_name }}
-      - run: poetry run deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     inputs:
-      environment:
+      deploy_env:
         required: true
         type: string
     secrets:
@@ -51,7 +51,7 @@ jobs:
       - name: deploy
         run: poetry run deploy
         env:
-          ENV: ${{ inputs.environment }}
+          ENV: ${{ inputs.deploy_env }}
           COGNITO_APP_SECRET: ${{ secrets.COGNITO_APP_SECRET }}
           STAC_INGESTOR_URL: ${{ secrets.STAC_INGESTOR_URL }}
           APP_NAME: "veda-data-pipelines"

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [develop, feature/gh-action-deploy]
+    branches: [develop]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -7,7 +7,7 @@ jobs:
     name: Deploy to dev environment
     uses: ./.github/workflows/deploy.yml
     with:
-      environment: dev
+      deploy_env: dev
     secrets:
       cognito_app_secret: ${{ secrets.cognito_app_secret }}
       aws_access_key_id: ${{ secrets.aws_access_key_id }}

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  deploy:
+    name: Deploy to dev environment
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: dev
+      cognito_app_secret: veda-auth-stack-alukach/veda-workflows
+

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [develop]
+    branches: [develop, feature/gh-action-deploy]
 
 jobs:
   deploy:
@@ -8,5 +8,9 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: dev
-      cognito_app_secret: veda-auth-stack-alukach/veda-workflows
+    secrets:
+      cognito_app_secret: ${{ secrets.cognito_app_secret }}
+      aws_access_key_id: ${{ secrets.aws_access_key_id }}
+      aws_secret_access_key: ${{ secrets.aws_secret_access_key }}
+      stac_ingestor_url: ${{ secrets.stac_ingestor_url }}
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -7,7 +7,7 @@ jobs:
     name: Deploy to staging environment
     uses: ./.github/workflows/deploy.yml
     with:
-      environment: stage
+      deploy_env: stage
     secrets:
       cognito_app_secret: ${{ secrets.cognito_app_secret }}
       aws_access_key_id: ${{ secrets.aws_access_key_id }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -8,4 +8,8 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: stage
-      cognito_app_secret: veda-auth-stack-alukach/veda-workflows
+    secrets:
+      cognito_app_secret: ${{ secrets.cognito_app_secret }}
+      aws_access_key_id: ${{ secrets.aws_access_key_id }}
+      aws_secret_access_key: ${{ secrets.aws_secret_access_key }}
+      stac_ingestor_url: ${{ secrets.stac_ingestor_url }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -7,7 +7,7 @@ jobs:
     name: Deploy to staging environment
     uses: ./.github/workflows/deploy.yml
     with:
-      deploy_env: stage
+      deploy_env: staging
     secrets:
       cognito_app_secret: ${{ secrets.cognito_app_secret }}
       aws_access_key_id: ${{ secrets.aws_access_key_id }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,11 @@
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy to staging environment
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: stage
+      cognito_app_secret: veda-auth-stack-alukach/veda-workflows

--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -1,0 +1,30 @@
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deploy environment'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+        - dev
+        - stage
+        - prod
+      cognito_app_secret:
+        description: 'AWS Cognito secret store'
+        type: string
+        required: false
+        default: veda-auth-stack-alukach/veda-workflows
+      app_name:
+        description: 'Application name'
+        type: string
+        required: false
+        default: veda-data-pipelines
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deploy_env: ${{ inputs.environment }}
+      cognito_app_secret: ${{ inputs.cognito_app_secret }}
+      app_name: ${{ inputs.app_name }}

--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -15,16 +15,20 @@ on:
         type: string
         required: false
         default: veda-auth-stack-alukach/veda-workflows
-      app_name:
-        description: 'Application name'
+      stac_ingestor_url:
+        description: 'URL for the stac ingestor API. (A deployment of https://github.com/NASA-IMPACT/veda-stac-ingestor)'
+        required: true
         type: string
-        required: false
-        default: veda-data-pipelines
+      external_role_arn:
+        description: 'ARN refering to the external IAM role which is assumed during ingests.'
+        required: true
+        type: string
 
 jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     with:
-      deploy_env: ${{ inputs.environment }}
+      environment: ${{ inputs.environment }}
       cognito_app_secret: ${{ inputs.cognito_app_secret }}
-      app_name: ${{ inputs.app_name }}
+      stac_ingestor_url: ${{ inputs.stac_ingestor_url }}
+      external_role_arn: ${{ inputs.external_role_arn }}

--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -1,34 +1,22 @@
 on:
   workflow_dispatch:
     inputs:
-      environment:
+      deploy_env:
         description: 'Deploy environment'
         required: true
         default: 'dev'
         type: choice
         options:
         - dev
-        - stage
-        - prod
-      cognito_app_secret:
-        description: 'AWS Cognito secret store'
-        type: string
-        required: false
-        default: veda-auth-stack-alukach/veda-workflows
-      stac_ingestor_url:
-        description: 'URL for the stac ingestor API. (A deployment of https://github.com/NASA-IMPACT/veda-stac-ingestor)'
-        required: true
-        type: string
-      external_role_arn:
-        description: 'ARN refering to the external IAM role which is assumed during ingests.'
-        required: true
-        type: string
+        - staging
 
 jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: ${{ inputs.environment }}
-      cognito_app_secret: ${{ inputs.cognito_app_secret }}
-      stac_ingestor_url: ${{ inputs.stac_ingestor_url }}
-      external_role_arn: ${{ inputs.external_role_arn }}
+    secrets:
+      cognito_app_secret: ${{ secrets.cognito_app_secret }}
+      aws_access_key_id: ${{ secrets.aws_access_key_id }}
+      aws_secret_access_key: ${{ secrets.aws_secret_access_key }}
+      stac_ingestor_url: ${{ secrets.stac_ingestor_url }}

--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -14,7 +14,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     with:
-      environment: ${{ inputs.environment }}
+      deploy_env: ${{ inputs.deploy_env }}
     secrets:
       cognito_app_secret: ${{ secrets.cognito_app_secret }}
       aws_access_key_id: ${{ secrets.aws_access_key_id }}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ EXTERNAL_ROLE_ARN="<arn-for-external-role-permissions>"
 
 ```bash
 chmod +x env.sh
-source env.sh <dev/stage>
+source env.sh <dev/staging>
 ```
 
 > If anything other than dev/stage is provided as the env, the dev credentials are used (for now).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This project uses AWS CDK to deploy AWS resources to the cloud.
 ENV="<dev/stage/prod>"
 COGNITO_APP_SECRET="<secret-name-for-pgstac-access>"
 APP_NAME="veda-data-pipelines"
+STAC_INGESTOR_URL="<url-for-ingestor-api>"
+EXTERNAL_ROLE_ARN="<arn-for-external-role-permissions>"
 ```
 
 **Note:** You can use the handy `env.sample.sh` script to set these variables. Just rename the file to `env.sh` and populate it with appropriate values. Then run the following commands:

--- a/env.sample.sh
+++ b/env.sample.sh
@@ -2,7 +2,7 @@
 # Script to populate the environment variables for CDK deployment/pgstac database ingestion
 
 # Usage: source env.sh <env>
-# Valid environments: dev, stage (for now)
+# Valid environments: dev, staging (for now)
 
 #===== Needed temporarily to load collections =====#
 devPGSecret=veda-backend-uah-dev/pgstac/621feede
@@ -26,7 +26,7 @@ if [[ -z $1 ]]
 then
     echo "please provide an environment as the first argument"
 else
-    if [[ $1 = 'stage' ]]
+    if [[ $1 = 'staging' ]]
     then
         cognitoAppSecret=$stageCognitoAppSecret
         pgSecret=$stagePGSecret


### PR DESCRIPTION
This PR adds support for GH action deployments in a few contexts:
1. on push to `main`, a deployment to staging
2. on push to `develop`, a deploy to dev
3. a `workflow_dispatch` mechanism to launch deployments in various environments

Closes #187 