### PR TITLE
Fix overly permissive prefix for item ingest

### DIFF
--- a/data/step_function_inputs/IS2SITMOGR4-cog.json
+++ b/data/step_function_inputs/IS2SITMOGR4-cog.json
@@ -1,6 +1,6 @@
 {
     "collection": "IS2SITMOGR4-cog",
-    "prefix": "IS2SITMOGR4-cog",
+    "prefix": "IS2SITMOGR4-cog/",
     "bucket": "veda-data-store-staging",
     "filename_regex": "^(.*).tif$",
     "discovery": "s3",

--- a/data/step_function_inputs/no2-monthly-orig.json
+++ b/data/step_function_inputs/no2-monthly-orig.json
@@ -1,6 +1,6 @@
 {
     "collection": "no2-monthly",
-    "prefix": "no2-monthly",
+    "prefix": "no2-monthly/",
     "bucket": "veda-data-store-staging",
     "filename_regex": "^(.*).tif$",
     "discovery": "s3",


### PR DESCRIPTION
This PR addresses prefixes which are overly permissive by adding a trailing slash to avoid any ambiguity about prefixes. This gave rise to a situation in which `no2-monthly` was ingested along with `no2-monthly-diff`.

Relates to #193