### PR TITLE
Fix session argument to rasterio.Env

### DIFF
--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -56,7 +56,8 @@ def create_item(
         )
 
     with rasterio.Env(
-        {
+        session=rasterio_kwargs["session"],
+        options={
             **rasterio_kwargs,
             "GDAL_MAX_DATASET_POOL_SIZE": 1024,
             "GDAL_DISABLE_READDIR_ON_OPEN": False,

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -64,7 +64,7 @@ def create_item(
             "GDAL_CACHEMAX": 1024000000,
             "GDAL_HTTP_MAX_RETRY": 4,
             "GDAL_HTTP_RETRY_DELAY": 1,
-        }
+        },
     ):
         return create_stac_item()
 


### PR DESCRIPTION
rasterio.Env expects a `session` argument rather than a a kwarg of `session`. This avoids errors during lambda publication