### PR TITLE
Add custom id for STAC items

### DIFF
--- a/lambdas/build-stac/tests/test_regex.py
+++ b/lambdas/build-stac/tests/test_regex.py
@@ -2,7 +2,7 @@ import pytest
 
 from datetime import datetime
 
-from utils import regex
+from utils import regex, events
 
 
 @pytest.mark.parametrize(
@@ -90,3 +90,35 @@ def test_date_extraction(test_input, expected):
     Ensure dateranges are properly extracted from filenames.
     """
     assert regex.extract_dates(*test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (
+            events.BaseEvent.parse_obj(
+                {
+                    "collection": "NO2",
+                    "s3_filename": "s3://OMNO2d_HRM/OMI_trno20.10x0.10_201601_Col3_V4.nc.tif",
+                    "id_regex": r"s3://([^/]*)/(.+).tif$",
+                }
+            ),
+            "OMNO2d_HRM-OMI_trno20.10x0.10_201601_Col3_V4.nc",
+        ),
+        (
+            events.BaseEvent.parse_obj(
+                {
+                    "collection": "NO2",
+                    "s3_filename": "s3://OMNO2d_HRMDifference/OMI_trno20.10x0.10_201601_Col3_V4.nc.tif",
+                    "id_regex": r"s3://([^/]*)/(.+).tif$",
+                }
+            ),
+            "OMNO2d_HRMDifference-OMI_trno20.10x0.10_201601_Col3_V4.nc",
+        ),
+    ],
+)
+def test_item_id_regex(input, expected):
+    """
+    Ensure dateranges are properly extracted from filenames.
+    """
+    assert input.item_id() == expected

--- a/lambdas/build-stac/utils/events.py
+++ b/lambdas/build-stac/utils/events.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 from typing import Dict, List, Literal, Optional, Union
+from pathlib import Path
+import re
 
 from pydantic import BaseModel, Field
 import pystac
@@ -12,9 +14,19 @@ class BaseEvent(BaseModel, frozen=True):
     collection: str
     s3_filename: str
 
+    id_regex: Optional[str] = None
     asset_name: Optional[str] = None
     asset_roles: Optional[List[str]] = None
     asset_media_type: Optional[Union[str, pystac.MediaType]] = None
+
+    def item_id(self: "BaseEvent") -> str:
+        if self.id_regex:
+            id_components = re.findall(self.id_regex, self.s3_filename)
+            assert len(id_components) == 1
+            id = "-".join(id_components[0])
+        else:
+            id = Path(self.s3_filename).stem
+        return id
 
 
 class CmrEvent(BaseEvent):

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -15,6 +15,7 @@ from . import regex, events, role
 
 
 def create_item(
+    id,
     properties,
     datetime,
     cog_url,
@@ -30,7 +31,7 @@ def create_item(
 
     def create_stac_item():
         return stac.create_stac_item(
-            id=Path(cog_url).stem,
+            id=id,
             source=cog_url,
             collection=collection,
             input_datetime=datetime,
@@ -97,6 +98,7 @@ def generate_stac_regexevent(item: events.RegexEvent) -> pystac.Item:
         single_datetime = None
 
     return create_item(
+        id=item.item_id(),
         properties=properties,
         datetime=single_datetime,
         cog_url=item.s3_filename,
@@ -115,6 +117,7 @@ def generate_stac_cmrevent(item: events.CmrEvent) -> pystac.Item:
     cmr_json = GranuleQuery().concept_id(item.granule_id).get(1)[0]
 
     return create_item(
+        id=item.item_id(),
         properties=cmr_json,
         datetime=str_to_datetime(cmr_json["time_start"]),
         cog_url=item.s3_filename,


### PR DESCRIPTION
Captures the s3 path to generate a custom id, using `id_regex`, for the STAC item.

`OMNO2d_HRMDifference/OMI_trno20.10x0.10_201601_Col3_V4.nc.tif` --> `OMNO2d_HRMDifference-OMI_trno20.10x0.10_201601_Col3_V4.nc`

Note: Items nested within deeper directory hierarchies will require a more complex regex. For e.g., `r"s3://((?:[^/]+/)*)(.+).tif$"` will capture the directory portion, _but_ this will require modifying the `item_id` function to fix the forward slashes in the first captured group.

Closes https://github.com/NASA-IMPACT/veda-data-pipelines/issues/197