### PR TITLE
Add future snow projection model outputs

### DIFF
--- a/data/collections/snow-projections-diff.json
+++ b/data/collections/snow-projections-diff.json
@@ -1,0 +1,44 @@
+{
+    "id": "snow-projections-diff",
+    "type": "Collection",
+    "links":[
+    ],
+    "title":"Projections of Snow Water Equivalent (SWE) losses",
+    "extent":{
+        "spatial":{
+            "bbox":[
+                [
+                    -125,
+                    34,
+                    -104,
+                    50,
+                ]
+            ]
+        },
+        "temporal":{
+            "interval":[
+                [
+                    "1995-04-01T00:00:00Z",
+                    "2095-05-01T00:00:00Z",
+                ]
+            ]
+        }
+    },
+    "license":"MIT",
+    "description": "Percent-change to future SWE, relative to the historical period (1995 - 2014), simulated using the LIS framework and CMIP6 climate projections downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+    "stac_version": "1.0.0",
+    "dashboard:is_periodic": false,
+    "dashboard:time_density": null,
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    }
+}
+

--- a/data/collections/snow-projections-mean.json
+++ b/data/collections/snow-projections-mean.json
@@ -1,0 +1,44 @@
+{
+    "id": "<collection-id>",
+    "type": "Collection",
+    "links":[
+    ],
+    "title":"<collection-title>",
+    "extent":{
+        "spatial":{
+            "bbox":[
+                [
+                    "<min-longitude>",
+                    "<min-latitude>",
+                    "<max-longitude>",
+                    "<max-latitude>",
+                ]
+            ]
+        },
+        "temporal":{
+            "interval":[
+                [
+                    "<start-date>",
+                    "<end-date>",
+                ]
+            ]
+        }
+    },
+    "license":"MIT",
+    "description": "<collection-description>",
+    "stac_version": "1.0.0",
+    "dashboard:is_periodic": "<true/false>",
+    "dashboard:time_density": "<month/>day/year>",
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    }
+}
+

--- a/data/collections/snow-projections-median.json
+++ b/data/collections/snow-projections-median.json
@@ -1,34 +1,34 @@
 {
-    "id": "<collection-id>",
+    "id": "snow-projections-median",
     "type": "Collection",
     "links":[
     ],
-    "title":"<collection-title>",
+    "title":"Projections of Snow Water Equivalent (SWE)",
     "extent":{
         "spatial":{
             "bbox":[
                 [
-                    "<min-longitude>",
-                    "<min-latitude>",
-                    "<max-longitude>",
-                    "<max-latitude>",
+                    -125,
+                    34,
+                    -104,
+                    50,
                 ]
             ]
         },
         "temporal":{
             "interval":[
                 [
-                    "<start-date>",
-                    "<end-date>",
+                    "1995-04-01T00:00:00Z",
+                    "2095-05-01T00:00:00Z",
                 ]
             ]
         }
     },
     "license":"MIT",
-    "description": "<collection-description>",
+    "description": "Historical (1995 - 2014) and future SWE simulated using the LIS framework and CMIP6 climate projections downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
     "stac_version": "1.0.0",
-    "dashboard:is_periodic": "<true/false>",
-    "dashboard:time_density": "<month/>day/year>",
+    "dashboard:is_periodic": false,
+    "dashboard:time_density": null,
     "item_assets": {
         "cog_default": {
             "type": "image/tiff; application=geotiff; profile=cloud-optimized",

--- a/data/step_function_inputs/snow-projections-diff.json
+++ b/data/step_function_inputs/snow-projections-diff.json
@@ -1,0 +1,66 @@
+[
+    {
+        "collection": "snow-projections-diff",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp245(.*)2017(.*)_percChange.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-diff",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp585(.*)2017(.*)_percChange.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {   
+        "collection": "snow-projections-diff",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp245(.*)2037(.*)_percChange.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {   
+        "collection": "snow-projections-diff",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp585(.*)2037(.*)_percChange.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {   
+        "collection": "snow-projections-diff",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp245(.*)2057(.*)_percChange.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {   
+        "collection": "snow-projections-diff",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp585(.*)2057(.*)_percChange.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {   
+        "collection": "snow-projections-diff",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp245(.*)2077(.*)_percChange.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {   
+        "collection": "snow-projections-diff",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp585(.*)2077(.*)_percChange.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    }
+]

--- a/data/step_function_inputs/snow-projections-median.json
+++ b/data/step_function_inputs/snow-projections-median.json
@@ -1,0 +1,74 @@
+[
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)2011(.*).tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp245(.*)2017(.*)_median.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp585(.*)2017(.*)_median.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp245(.*)2037(.*)_median.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp585(.*)2037(.*)_median.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp245(.*)2057(.*)_median.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp585(.*)2057(.*)_median.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp245(.*)2077(.*)_median.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    },
+    {
+        "collection": "snow-projections-median",
+        "prefix": "EIS/snowProjections/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)ssp585(.*)2077(.*)_median.cog.tif$",
+        "discovery": "s3",
+        "upload": false
+    }
+]


### PR DESCRIPTION
Added collection metadata and inputs to the step function for simulated snow projections. Data includes SWE maps `snow-projections-median.json` and SWE difference maps `snow-projections-diff.json`. 

This corresponds to issue #237.