### PR TITLE
Add Github Action to validate newly created datasets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm install -g aws-cdk
 
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/validate_dataset.yml
+++ b/.github/workflows/validate_dataset.yml
@@ -28,7 +28,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Filter for dataset files
         uses: dorny/paths-filter@v2
         id: filter

--- a/.github/workflows/validate_dataset.yml
+++ b/.github/workflows/validate_dataset.yml
@@ -57,15 +57,16 @@ jobs:
             echo "Validating $file"
             token=$(cat token.txt | jq -r '.access_token')
             # if 200 not returned, set outputs to print code and message
-            http_response=$(curl -N -s -o response-${file}.txt -w "%{http_code}" -X POST \
+            http_response=$(curl -N -s -o response.txt -w "%{http_code}" -X POST \
               -H "Content-Type: application/json" \
-              -H "Authorization: Bearer: $token" \
+              -H "Authorization: Bearer $token" \
+              -H "accept: application/json"\
               -d @$file \
-              "$STAC_INGESTOR_URL/datasets/validate")
+              "$STAC_INGESTOR_URL/dataset/validate")
             if [ $http_response -ne 200 ]; then
               echo "Error validating $file"
               echo "HTTP Response: $http_response"
-              echo "Response Body: $(cat response-${file}.txt)"
+              echo "Response Body: $(cat response.txt)"
               error_flag=1
             fi
           done

--- a/.github/workflows/validate_dataset.yml
+++ b/.github/workflows/validate_dataset.yml
@@ -31,13 +31,12 @@ jobs:
           list-files: shell
           filters: |
             dataset:
-              - 'data/datasets/*.json'
+              - added|modified: 'data/datasets/*.json'
       - name: Validate datasets using API
         if: steps.filter.outputs.dataset == 'true'
         env:
           STAC_INGESTOR_URL: ${{ secrets.STAC_INGESTOR_URL }}
         shell: bash
-        # LIMITATION - only reports errors in first CURL that fails
         run: |
           curl -X POST \
             -H "Content-Type: application/x-www-form-urlencoded" \

--- a/.github/workflows/validate_dataset.yml
+++ b/.github/workflows/validate_dataset.yml
@@ -1,0 +1,74 @@
+name: Validate Datasets
+
+# on .json PR to /data/datasets folder
+on: 
+  push:
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+      cognito_app_secret:
+        required: true
+      stac_ingestor_url:
+        required: true
+      client_id:
+        required: true
+      client_secret:
+        required: true
+      cognito_domain:
+        required: true
+      scope:
+        required: true
+    paths:
+      - 'data/datasets/**'
+
+# send pushed file as body to (API)/datasets/validate using secret credentials
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Filter for dataset files
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: 'main'
+          list-files: shell
+          filters: |
+            dataset:
+              - 'data/datasets/*.json'
+      - name: Validate datasets using API
+        if: steps.filter.outputs.dataset == 'true'
+        env:
+          COGNITO_APP_SECRET: ${{ secrets.COGNITO_APP_SECRET }}
+          STAC_INGESTOR_URL: ${{ secrets.STAC_INGESTOR_URL }}
+        shell: bash
+        # LIMITATION - only reports errors in first CURL that fails
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials&scope=${{ secrets.scope }}" \
+            -u "${{ secrets.client_id }}:${{ secrets.client_secret }}" \
+            "${{ secrets.cognito_domain }}/oauth2/token" > token.txt
+          error_flag=0
+          for file in ${{ steps.filter.outputs.dataset_files }}
+          do
+            echo "Validating $file"
+            token=$(cat token.txt | jq -r '.access_token')
+            # if 200 not returned, set outputs to print code and message
+            http_response=$(curl -N -s -o response-${file}.txt -w "%{http_code}" -X POST \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer: $token" \
+              -d @$file \
+              "$STAC_INGESTOR_URL/datasets/validate")
+            if [ $http_response -ne 200 ]; then
+              echo "Error validating $file"
+              echo "HTTP Response: $http_response"
+              echo "Response Body: $(cat response-${file}.txt)"
+              error_flag=1
+            fi
+          done
+          if [ $error_flag -eq 1 ]; then
+            exit 1
+          fi

--- a/.github/workflows/validate_dataset.yml
+++ b/.github/workflows/validate_dataset.yml
@@ -4,12 +4,6 @@ name: Validate Datasets
 on: 
   push:
     secrets:
-      aws_access_key_id:
-        required: true
-      aws_secret_access_key:
-        required: true
-      cognito_app_secret:
-        required: true
       stac_ingestor_url:
         required: true
       client_id:
@@ -41,7 +35,6 @@ jobs:
       - name: Validate datasets using API
         if: steps.filter.outputs.dataset == 'true'
         env:
-          COGNITO_APP_SECRET: ${{ secrets.COGNITO_APP_SECRET }}
           STAC_INGESTOR_URL: ${{ secrets.STAC_INGESTOR_URL }}
         shell: bash
         # LIMITATION - only reports errors in first CURL that fails

--- a/data/datasets/caldor-fire-behavior.json
+++ b/data/datasets/caldor-fire-behavior.json
@@ -4,7 +4,7 @@
     "description": "`.geojson` and `tif` files describing the progression and active fire behavior of the 2021 Caldor Fire in California via the algorithm detailed in https://www.nature.com/articles/s41597-022-01343-0. This includes an extra `.tif` file detailing the soil burn severity (SBS) conditions provided by the [Burned Area Emergency Response](https://burnseverity.cr.usgs.gov/baer/) team.",
     "license": "CC0",
     "dashboard_is_periodic": false,
-    "dashboard_time_density": "null",
+    "dashboard_time_density": null,
     "spatial_extent": {
         "xmin": -180,
         "ymin": -90,

--- a/data/datasets/caldor-fire-behavior.json
+++ b/data/datasets/caldor-fire-behavior.json
@@ -3,8 +3,8 @@
     "title": "Caldor Fire Behavior",
     "description": "`.geojson` and `tif` files describing the progression and active fire behavior of the 2021 Caldor Fire in California via the algorithm detailed in https://www.nature.com/articles/s41597-022-01343-0. This includes an extra `.tif` file detailing the soil burn severity (SBS) conditions provided by the [Burned Area Emergency Response](https://burnseverity.cr.usgs.gov/baer/) team.",
     "license": "CC0",
-    "dashboard_is_periodic": false,
-    "dashboard_time_density": null,
+    "is_periodic": false,
+    "time_density": null,
     "spatial_extent": {
         "xmin": -180,
         "ymin": -90,

--- a/data/datasets/caldor-fire-behavior.json
+++ b/data/datasets/caldor-fire-behavior.json
@@ -1,0 +1,31 @@
+{
+    "collection": "caldor-fire-behavior",
+    "title": "Caldor Fire Behavior",
+    "description": "`.geojson` and `tif` files describing the progression and active fire behavior of the 2021 Caldor Fire in California via the algorithm detailed in https://www.nature.com/articles/s41597-022-01343-0. This includes an extra `.tif` file detailing the soil burn severity (SBS) conditions provided by the [Burned Area Emergency Response](https://burnseverity.cr.usgs.gov/baer/) team.",
+    "license": "CC0",
+    "dashboard_is_periodic": false,
+    "dashboard_time_density": "null",
+    "spatial_extent": {
+        "xmin": -180,
+        "ymin": -90,
+        "xmax": 180,
+        "ymax": 90
+    },
+    "temporal_extent": {
+        "startdate": "2021-08-14T00:00:00Z",
+        "enddate": "2021-10-21T23:59:59Z"
+    },
+    "sample_files": [
+        "EIS/COG/Fire-Hydro/frp_to_save.tif"
+    ],
+    "discovery_items": [
+        {
+        "discovery": "s3",
+        "prefix": "EIS/COG/Fire-Hydro/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)frp_to_save.tif$",
+        "start_datetime": "2021-08-15T00:00:00Z",
+        "end_datetime": "2021-10-21T12:00:00Z"
+        }
+    ]
+}

--- a/deploy/app.py
+++ b/deploy/app.py
@@ -1,17 +1,38 @@
 #!/usr/bin/env python3
 import os
+import subprocess
+from getpass import getuser
 
-from aws_cdk import core
+import aws_cdk
+from aws_cdk import App, Environment
 
 from cdk.lambda_stack import LambdaStack
 from cdk.step_function_stack import StepFunctionStack
 from cdk.queue_stack import QueueStack
+from cdk.util_stack import DataPipelineUtilStack
 
-import config
+import config as cfg
 
-app = core.App()
+app = App()
 
-env_details = core.Environment(
+config = cfg.Config(_env_file=".env")
+
+git_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+try:
+    git_tag = subprocess.check_output(["git", "describe", "--tags"]).decode().strip()
+except subprocess.CalledProcessError:
+    git_tag = "no-tag"
+
+tags = {
+    "Project": "veda",
+    "Owner": config.owner,
+    "Client": "nasa-impact",
+    "Stack": config.ENV,
+    "GitCommit": git_sha,
+    "GitTag": git_tag,
+}
+
+env_details = Environment(
     region=os.environ["CDK_DEFAULT_REGION"],
     account=os.environ["CDK_DEFAULT_ACCOUNT"],
 )
@@ -37,6 +58,14 @@ step_function_stack = StepFunctionStack(
     env=env_details,
 )
 
+# ENV secret, OIDC support (if enabled)
+util_stack = DataPipelineUtilStack(
+    app,
+    f"{config.APP_NAME}-{config.ENV}-util",
+    env=env_details,
+)
+
+
 # Need to build arn manually otherwise it'll result in cyclic dependency
 cogify_arn = step_function_stack.build_arn(env_details, "cogify")
 pub_arn = step_function_stack.build_arn(env_details, "publication")
@@ -49,5 +78,11 @@ lambda_stack.grant_execution_privileges(
     lambda_function=lambda_stack.trigger_ingest_lambda,
     workflow_arn=pub_arn,
 )
+
+
+
+
+for key, value in tags.items():
+    aws_cdk.Tags.of(app).add(key, value)
 
 app.synth()

--- a/deploy/cdk.json
+++ b/deploy/cdk.json
@@ -1,12 +1,9 @@
 {
   "app": "python3 app.py",
   "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
     "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true
+    "@aws-cdk/aws-kms:defaultKeyPolicies": true
   }
 }

--- a/deploy/cdk/lambda_stack.py
+++ b/deploy/cdk/lambda_stack.py
@@ -1,16 +1,18 @@
 from aws_cdk import (
-    core,
+    Stack,
+    Duration,
     aws_lambda,
-    aws_lambda_python,
+    aws_lambda_python_alpha as aws_lambda_python,
     aws_iam as iam,
     aws_s3 as s3,
     aws_secretsmanager as secretsmanager,
 )
 
-import config
+import config as cfg
 
+config = cfg.Config(_env_file=".env")
 
-class LambdaStack(core.Stack):
+class LambdaStack(Stack):
     def __init__(self, app, construct_id, **kwargs) -> None:
         super().__init__(app, construct_id, **kwargs)
         self.construct_id = construct_id
@@ -135,7 +137,7 @@ class LambdaStack(core.Stack):
             handler=aws_lambda.Handler.FROM_IMAGE,
             runtime=aws_lambda.Runtime.FROM_IMAGE,
             memory_size=memory_size,
-            timeout=core.Duration.seconds(timeout_seconds),
+            timeout=Duration.seconds(timeout_seconds),
             environment=env,
             reserved_concurrent_executions=reserved_concurrent_executions,
             **kwargs,
@@ -151,7 +153,7 @@ class LambdaStack(core.Stack):
             index="handler.py",
             handler="handler",
             environment=env,
-            timeout=core.Duration.seconds(timeout_seconds),
+            timeout=Duration.seconds(timeout_seconds),
             **kwargs,
         )
 

--- a/deploy/cdk/queue_stack.py
+++ b/deploy/cdk/queue_stack.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from aws_cdk import (
-    core,
+    Stack,
+    Duration,
     aws_sqs as sqs,
     aws_lambda_event_sources as lambda_event_sources,
 )
@@ -9,7 +10,7 @@ if TYPE_CHECKING:
     from .lambda_stack import LambdaStack
 
 
-class QueueStack(core.Stack):
+class QueueStack(Stack):
     def __init__(
         self,
         app,
@@ -32,7 +33,7 @@ class QueueStack(core.Stack):
             lambda_event_sources.SqsEventSource(
                 self.cogify_queue,
                 batch_size=10,
-                max_batching_window=core.Duration.seconds(20),
+                max_batching_window=Duration.seconds(20),
                 report_batch_item_failures=True,
             )
         )
@@ -51,7 +52,7 @@ class QueueStack(core.Stack):
             lambda_event_sources.SqsEventSource(
                 self.stac_ready_queue,
                 batch_size=10,
-                max_batching_window=core.Duration.seconds(30),
+                max_batching_window=Duration.seconds(30),
                 report_batch_item_failures=True,
             )
         )
@@ -63,7 +64,7 @@ class QueueStack(core.Stack):
             self,
             name,
             queue_name=name,
-            visibility_timeout=core.Duration.seconds(visibility_timeout),
+            visibility_timeout=Duration.seconds(visibility_timeout),
             dead_letter_queue=dead_letter_queue,
-            retention_period=core.Duration.days(retention_days),
+            retention_period=Duration.days(retention_days),
         )

--- a/deploy/cdk/step_function_stack.py
+++ b/deploy/cdk/step_function_stack.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from aws_cdk import (
-    core,
+    Stack,
+    Duration,
     aws_stepfunctions as stepfunctions,
     aws_stepfunctions_tasks as tasks,
 )
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
     from .lambda_stack import LambdaStack
 
 
-class StepFunctionStack(core.Stack):
+class StepFunctionStack(Stack):
     def __init__(
         self,
         app,
@@ -166,7 +167,7 @@ class StepFunctionStack(core.Stack):
 
         build_stac_item_task.add_retry(
             errors=["RasterioIOError"],
-            interval=core.Duration.seconds(2),
+            interval=Duration.seconds(2),
             max_attempts=5,
         )
 

--- a/deploy/config.py
+++ b/deploy/config.py
@@ -1,21 +1,55 @@
-import os
+from getpass import getuser
 
+from pydantic import BaseSettings, Field
 
-ENV = os.environ.get("ENV")
+class Config(BaseSettings):
+    owner: str = Field(
+        description=" ".join(
+            [
+                "Name of primary contact for Cloudformation Stack.",
+                "Used to tag generated resources",
+                "Defaults to current username.",
+            ]
+        ),
+        default_factory=getuser,
+    )
 
-COGNITO_APP_SECRET = os.environ["COGNITO_APP_SECRET"]
-STAC_INGESTOR_URL = os.environ["STAC_INGESTOR_URL"]
+    ENV: str = Field(
+        Description="Environment name (defaults to current username)",
+        env='ENV',
+        default_factory=getuser
+    )
 
-EARTHDATA_USERNAME = os.environ.get("EARTHDATA_USERNAME", "XXXX")
-EARTHDATA_PASSWORD = os.environ.get("EARTHDATA_PASSWORD", "XXXX")
+    COGNITO_APP_SECRET: str = Field(
+        Description="Cognito app secret",
+        env='COGNITO_APP_SECRET',
+    )
+    STAC_INGESTOR_URL: str = Field(
+        Description="URL of STAC Ingestor",
+        env='STAC_INGESTOR_URL',
+    )
 
-APP_NAME = "veda-data-pipelines"
-VEDA_DATA_BUCKET = "climatedashboard-data"
-VEDA_EXTERNAL_BUCKETS = ["nasa-maap-data-store", "covid-eo-blackmarble"]
-MCP_BUCKETS = {
-    "prod": "veda-data-store",
-    "stage": "veda-data-store-staging",
-}
+    EARTHDATA_USERNAME: str = Field(
+        Description="Earthdata username",
+        env='EARTHDATA_USERNAME',
+        default="XXXX"
+    )
+    EARTHDATA_PASSWORD: str = Field(
+        Description="Earthdata password",
+        env='EARTHDATA_PASSWORD',
+        default="XXXX"
+    )
 
-# This should throw if it is not provided
-EXTERNAL_ROLE_ARN = os.environ["EXTERNAL_ROLE_ARN"]
+    APP_NAME: str = "veda-data-pipelines"
+    VEDA_DATA_BUCKET: str = "climatedashboard-data"
+    VEDA_EXTERNAL_BUCKETS = ["nasa-maap-data-store", "covid-eo-blackmarble"]
+    MCP_BUCKETS = {
+        "prod": "veda-data-store",
+        "stage": "veda-data-store-staging",
+    }
+
+    # This should throw if it is not provided
+    EXTERNAL_ROLE_ARN: str = Field(
+        Description="ARN of role to assume for external buckets",
+        env='EXTERNAL_ROLE_ARN',
+    )

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,14 +1,2 @@
-aws_cdk.core==1.151.0
-aws_cdk.aws_iam==1.151.0
-aws_cdk.custom_resources==1.151.0
-aws_cdk.aws_stepfunctions==1.151.0
-aws_cdk.aws_events==1.151.0
-aws_cdk.aws_events_targets==1.151.0
-aws_cdk.aws_secretsmanager==1.151.0
-aws_cdk.aws_lambda==1.151.0
-aws_cdk.aws_stepfunctions_tasks==1.151.0
-aws_cdk.aws_ec2==1.151.0
-aws_cdk.aws_sqs==1.151.0
-aws_cdk.aws_s3==1.151.0
-aws_cdk.aws_lambda_event_sources==1.151.0
-aws_cdk.aws_lambda_python==1.151.0
+aws-cdk-lib==2.68.0
+aws-cdk.aws-lambda-python-alpha==2.68.0a0


### PR DESCRIPTION
Tracked by #259 

Bit of a learning curve to get this action up and running, criticism is appreciated 😄 

PR includes sample input under `/data/datasets/`. 

To test, use act to run `act push -j validate --secret-file .secrets`. A dataset file must be committed for the action to register it as a new dataset, and a `.secrets` file must be placed in the repository root. This file contains the following, and can be used to test actions other than the new one (which is why it contains more variables than are used in this PR):

```
AWS_ACCESS_KEY_ID=<your own key>
AWS_SECRET_ACCESS_KEY=<your own key>
COGNITO_APP_SECRET=<same secret used to deploy veda-stac-ingestor>
STAC_INGESTOR_URL=<stac-ingestor url>
# the following values are taken from the `cognito_app_secret`
client_id=<>
client_secret=<>
cognito_domain=<>
scope=<>
```

A future task is setting up an auth flow (using an OIDC provider to assume IAM roles) to allow our action to access secrets from AWS Secrets Manager. I had a functioning process established, but I excluded it from this PR, as I wanted to be extra cautious about creating that kind of access. This is something we might be able to standardize across our projects and implement as part of [#113](https://github.com/NASA-IMPACT/veda-architecture/issues/113)