### PR TITLE
Ensure appropriate serialization of date strings (rfc3339)

### DIFF
--- a/lambdas/build-stac/utils/regex.py
+++ b/lambdas/build-stac/utils/regex.py
@@ -1,6 +1,6 @@
 import re
 from typing import Callable, Dict, Tuple, Union
-from datetime import datetime
+from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
 
 from . import events
@@ -48,7 +48,9 @@ def extract_dates(
             continue
 
         for date_str in dates_found:
-            dates.append(datetime.strptime(date_str, dateformat))
+            date = datetime.strptime(date_str, dateformat)
+            date_tz = date.replace(tzinfo=timezone.utc)
+            dates.append(date_tz)
 
         break
 

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -93,8 +93,9 @@ def generate_stac_regexevent(item: events.RegexEvent) -> pystac.Item:
         )
     properties = item.properties or {}
     if start_datetime and end_datetime:
-        properties["start_datetime"] = start_datetime.isoformat()
-        properties["end_datetime"] = end_datetime.isoformat()
+        # these are added post-serialization to properties, unlike single_datetime
+        properties["start_datetime"] = start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
+        properties["end_datetime"] = end_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
         single_datetime = None
 
     return create_item(


### PR DESCRIPTION
This PR adds timezone information at the point of `datetime` creation and appropriately uses `strftime` (not `isoformat`) to serialize datetimes for stac creation.

Closes #270 