### PR TITLE
Add 20-year projections of Western US winter precip and temp

### DIFF
--- a/data/collections/CMIP245-winter-median-pr.json
+++ b/data/collections/CMIP245-winter-median-pr.json
@@ -1,8 +1,7 @@
 {
     "id": "CMIP245-winter-median-pr",
     "type": "Collection",
-    "links":[
-    ],
+    "links":[],
     "title":"Projected changes to winter (January, February, and March) cumulative daily precipitation",
     "extent":{
         "spatial":{
@@ -11,7 +10,7 @@
                     -127,
                     29,
                     -103,
-                    52,
+                    52
                 ]
             ]
         },
@@ -19,7 +18,7 @@
             "interval":[
                 [
                     "1995-01-01T00:00:00Z",
-                    "2095-03-31T00:00:00Z",
+                    "2095-03-31T00:00:00Z"
                 ]
             ]
         }

--- a/data/collections/CMIP245-winter-median-pr.json
+++ b/data/collections/CMIP245-winter-median-pr.json
@@ -1,0 +1,44 @@
+{
+    "id": "CMIP245-winter-median-pr",
+    "type": "Collection",
+    "links":[
+    ],
+    "title":"End-of-century projected changes to winter (January, February, and March) precipitation",
+    "extent":{
+        "spatial":{
+            "bbox":[
+                [
+                    -127,
+                    29,
+                    -103,
+                    52,
+                ]
+            ]
+        },
+        "temporal":{
+            "interval":[
+                [
+                    "1995-01-01T00:00:00Z",
+                    "2095-03-31T00:00:00Z",
+                ]
+            ]
+        }
+    },
+    "license":"MIT",
+    "description": "Differences in winter (January, February, and March) cumulative precipitation between a historical period (1995 - 2014) and an end-of-century period (2076 - 2095) from CMIP6 climate projections downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+    "stac_version": "1.0.0",
+    "dashboard:is_periodic": false,
+    "dashboard:time_density": null,
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    }
+}
+

--- a/data/collections/CMIP245-winter-median-ta.json
+++ b/data/collections/CMIP245-winter-median-ta.json
@@ -3,7 +3,7 @@
     "type": "Collection",
     "links":[
     ],
-    "title":"End-of-century projected changes to winter (January, February, and March) air temperature",
+    "title":"Projected changes to winter (January, February, and March) average daily air temperature",
     "extent":{
         "spatial":{
             "bbox":[
@@ -25,7 +25,7 @@
         }
     },
     "license":"MIT",
-    "description": "Differences in winter (January, February, and March) average air temperature between a historical period (1995 - 2014) and an end-of-century period (2076 - 2095) from CMIP6 climate projections downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+    "description": "Differences in winter (January, February, and March) average daily air temperature between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP2-4.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
     "stac_version": "1.0.0",
     "dashboard:is_periodic": false,
     "dashboard:time_density": null,

--- a/data/collections/CMIP245-winter-median-ta.json
+++ b/data/collections/CMIP245-winter-median-ta.json
@@ -1,44 +1,27 @@
 {
-    "id": "CMIP245-winter-median-ta",
-    "type": "Collection",
-    "links":[
-    ],
-    "title":"Projected changes to winter (January, February, and March) average daily air temperature",
-    "extent":{
-        "spatial":{
-            "bbox":[
-                [
-                    -127,
-                    29,
-                    -103,
-                    52,
-                ]
-            ]
-        },
-        "temporal":{
-            "interval":[
-                [
-                    "1995-01-01T00:00:00Z",
-                    "2095-03-31T00:00:00Z",
-                ]
-            ]
-        }
+  "id": "CMIP245-winter-median-ta",
+  "type": "Collection",
+  "links": [],
+  "title": "Projected changes to winter (January, February, and March) average daily air temperature",
+  "extent": {
+    "spatial": {
+      "bbox": [[-127, 29, -103, 52]]
     },
-    "license":"MIT",
-    "description": "Differences in winter (January, February, and March) average daily air temperature between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP2-4.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
-    "stac_version": "1.0.0",
-    "dashboard:is_periodic": false,
-    "dashboard:time_density": null,
-    "item_assets": {
-        "cog_default": {
-            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "roles": [
-                "data",
-                "layer"
-            ],
-            "title": "Default COG Layer",
-            "description": "Cloud optimized default layer to display on map"
-        }
+    "temporal": {
+      "interval": [["1995-01-01T00:00:00Z", "2095-03-31T00:00:00Z"]]
     }
+  },
+  "license": "MIT",
+  "description": "Differences in winter (January, February, and March) average daily air temperature between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP2-4.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+  "stac_version": "1.0.0",
+  "dashboard:is_periodic": false,
+  "dashboard:time_density": null,
+  "item_assets": {
+    "cog_default": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data", "layer"],
+      "title": "Default COG Layer",
+      "description": "Cloud optimized default layer to display on map"
+    }
+  }
 }
-

--- a/data/collections/CMIP245-winter-median-ta.json
+++ b/data/collections/CMIP245-winter-median-ta.json
@@ -1,0 +1,44 @@
+{
+    "id": "CMIP245-winter-median-ta",
+    "type": "Collection",
+    "links":[
+    ],
+    "title":"End-of-century projected changes to winter (January, February, and March) air temperature",
+    "extent":{
+        "spatial":{
+            "bbox":[
+                [
+                    -127,
+                    29,
+                    -103,
+                    52,
+                ]
+            ]
+        },
+        "temporal":{
+            "interval":[
+                [
+                    "1995-01-01T00:00:00Z",
+                    "2095-03-31T00:00:00Z",
+                ]
+            ]
+        }
+    },
+    "license":"MIT",
+    "description": "Differences in winter (January, February, and March) average air temperature between a historical period (1995 - 2014) and an end-of-century period (2076 - 2095) from CMIP6 climate projections downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+    "stac_version": "1.0.0",
+    "dashboard:is_periodic": false,
+    "dashboard:time_density": null,
+    "item_assets": {
+        "cog_default": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map"
+        }
+    }
+}
+

--- a/data/collections/CMIP585-winter-median-pr.json
+++ b/data/collections/CMIP585-winter-median-pr.json
@@ -1,5 +1,5 @@
 {
-    "id": "CMIP245-winter-median-pr",
+    "id": "CMIP585-winter-median-pr",
     "type": "Collection",
     "links":[
     ],
@@ -25,7 +25,7 @@
         }
     },
     "license":"MIT",
-    "description": "Differences in winter (January, February, and March) cumulative daily precipitation between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP2-4.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+    "description": "Differences in winter (January, February, and March) cumulative daily precipitation between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP5-8.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
     "stac_version": "1.0.0",
     "dashboard:is_periodic": false,
     "dashboard:time_density": null,

--- a/data/collections/CMIP585-winter-median-pr.json
+++ b/data/collections/CMIP585-winter-median-pr.json
@@ -1,44 +1,27 @@
 {
-    "id": "CMIP585-winter-median-pr",
-    "type": "Collection",
-    "links":[
-    ],
-    "title":"Projected changes to winter (January, February, and March) cumulative daily precipitation",
-    "extent":{
-        "spatial":{
-            "bbox":[
-                [
-                    -127,
-                    29,
-                    -103,
-                    52,
-                ]
-            ]
-        },
-        "temporal":{
-            "interval":[
-                [
-                    "1995-01-01T00:00:00Z",
-                    "2095-03-31T00:00:00Z",
-                ]
-            ]
-        }
+  "id": "CMIP585-winter-median-pr",
+  "type": "Collection",
+  "links": [],
+  "title": "Projected changes to winter (January, February, and March) cumulative daily precipitation",
+  "extent": {
+    "spatial": {
+      "bbox": [[-127, 29, -103, 52]]
     },
-    "license":"MIT",
-    "description": "Differences in winter (January, February, and March) cumulative daily precipitation between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP5-8.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
-    "stac_version": "1.0.0",
-    "dashboard:is_periodic": false,
-    "dashboard:time_density": null,
-    "item_assets": {
-        "cog_default": {
-            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "roles": [
-                "data",
-                "layer"
-            ],
-            "title": "Default COG Layer",
-            "description": "Cloud optimized default layer to display on map"
-        }
+    "temporal": {
+      "interval": [["1995-01-01T00:00:00Z", "2095-03-31T00:00:00Z"]]
     }
+  },
+  "license": "MIT",
+  "description": "Differences in winter (January, February, and March) cumulative daily precipitation between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP5-8.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+  "stac_version": "1.0.0",
+  "dashboard:is_periodic": false,
+  "dashboard:time_density": null,
+  "item_assets": {
+    "cog_default": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data", "layer"],
+      "title": "Default COG Layer",
+      "description": "Cloud optimized default layer to display on map"
+    }
+  }
 }
-

--- a/data/collections/CMIP585-winter-median-ta.json
+++ b/data/collections/CMIP585-winter-median-ta.json
@@ -1,9 +1,9 @@
 {
-    "id": "CMIP245-winter-median-pr",
+    "id": "CMIP585-winter-median-ta",
     "type": "Collection",
     "links":[
     ],
-    "title":"Projected changes to winter (January, February, and March) cumulative daily precipitation",
+    "title":"Projected changes to winter (January, February, and March) average daily air temperature",
     "extent":{
         "spatial":{
             "bbox":[
@@ -25,7 +25,7 @@
         }
     },
     "license":"MIT",
-    "description": "Differences in winter (January, February, and March) cumulative daily precipitation between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP2-4.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+    "description": "Differences in winter (January, February, and March) average daily air temperature between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP5-8.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
     "stac_version": "1.0.0",
     "dashboard:is_periodic": false,
     "dashboard:time_density": null,

--- a/data/collections/CMIP585-winter-median-ta.json
+++ b/data/collections/CMIP585-winter-median-ta.json
@@ -1,44 +1,27 @@
 {
-    "id": "CMIP585-winter-median-ta",
-    "type": "Collection",
-    "links":[
-    ],
-    "title":"Projected changes to winter (January, February, and March) average daily air temperature",
-    "extent":{
-        "spatial":{
-            "bbox":[
-                [
-                    -127,
-                    29,
-                    -103,
-                    52,
-                ]
-            ]
-        },
-        "temporal":{
-            "interval":[
-                [
-                    "1995-01-01T00:00:00Z",
-                    "2095-03-31T00:00:00Z",
-                ]
-            ]
-        }
+  "id": "CMIP585-winter-median-ta",
+  "type": "Collection",
+  "links": [],
+  "title": "Projected changes to winter (January, February, and March) average daily air temperature",
+  "extent": {
+    "spatial": {
+      "bbox": [[-127, 29, -103, 52]]
     },
-    "license":"MIT",
-    "description": "Differences in winter (January, February, and March) average daily air temperature between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP5-8.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
-    "stac_version": "1.0.0",
-    "dashboard:is_periodic": false,
-    "dashboard:time_density": null,
-    "item_assets": {
-        "cog_default": {
-            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "roles": [
-                "data",
-                "layer"
-            ],
-            "title": "Default COG Layer",
-            "description": "Cloud optimized default layer to display on map"
-        }
+    "temporal": {
+      "interval": [["1995-01-01T00:00:00Z", "2095-03-31T00:00:00Z"]]
     }
+  },
+  "license": "MIT",
+  "description": "Differences in winter (January, February, and March) average daily air temperature between a historical period (1995 - 2014) and multiple 20-year periods from an ensemble of CMIP6 climate projections (SSP5-8.5) downscaled by NASA Earth Exchange (NEX-GDDP-CMIP6)",
+  "stac_version": "1.0.0",
+  "dashboard:is_periodic": false,
+  "dashboard:time_density": null,
+  "item_assets": {
+    "cog_default": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": ["data", "layer"],
+      "title": "Default COG Layer",
+      "description": "Cloud optimized default layer to display on map"
+    }
+  }
 }
-

--- a/data/step_function_inputs/CMIP245-winter-median-pr.json
+++ b/data/step_function_inputs/CMIP245-winter-median-pr.json
@@ -3,7 +3,7 @@
         "collection": "CMIP245-winter-median-pr",
         "prefix": "EIS/NEX-GDDP-CMIP6/",
         "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)ssp245(.*)winter_pr(.*).cog.tif$",
+        "filename_regex": "^(.*)_pr(.*)ssp245(.*).cog.tif$",
         "discovery": "s3",
         "upload": false
     }

--- a/data/step_function_inputs/CMIP245-winter-median-pr.json
+++ b/data/step_function_inputs/CMIP245-winter-median-pr.json
@@ -1,0 +1,10 @@
+[
+    {
+        "collection": "CMIP245-winter-median-pr",
+        "prefix": "EIS/NEX-GDDP-CMIP6/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)winterPr(.*).tif$",
+        "discovery": "s3",
+        "upload": false
+    }
+]

--- a/data/step_function_inputs/CMIP245-winter-median-pr.json
+++ b/data/step_function_inputs/CMIP245-winter-median-pr.json
@@ -1,10 +1,8 @@
-[
-    {
-        "collection": "CMIP245-winter-median-pr",
-        "prefix": "EIS/NEX-GDDP-CMIP6/",
-        "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)_pr(.*)ssp245(.*).cog.tif$",
-        "discovery": "s3",
-        "upload": false
-    }
-]
+{
+  "collection": "CMIP245-winter-median-pr",
+  "prefix": "EIS/NEX-GDDP-CMIP6/",
+  "bucket": "veda-data-store-staging",
+  "filename_regex": "^(.*)_pr(.*)ssp245(.*).cog.tif$",
+  "discovery": "s3",
+  "upload": false
+}

--- a/data/step_function_inputs/CMIP245-winter-median-ta.json
+++ b/data/step_function_inputs/CMIP245-winter-median-ta.json
@@ -3,7 +3,7 @@
         "collection": "CMIP245-winter-median-ta",
         "prefix": "EIS/NEX-GDDP-CMIP6/",
         "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)ssp245(.*)winter_ta(.*).cog.tif$",
+        "filename_regex": "^(.*)_tas(.*)ssp245(.*).cog.tif$",
         "discovery": "s3",
         "upload": false
     }

--- a/data/step_function_inputs/CMIP245-winter-median-ta.json
+++ b/data/step_function_inputs/CMIP245-winter-median-ta.json
@@ -3,7 +3,7 @@
         "collection": "CMIP245-winter-median-ta",
         "prefix": "EIS/NEX-GDDP-CMIP6/",
         "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)winterTas(.*).tif$",
+        "filename_regex": "^(.*)ssp245(.*)winter_ta(.*).cog.tif$",
         "discovery": "s3",
         "upload": false
     }

--- a/data/step_function_inputs/CMIP245-winter-median-ta.json
+++ b/data/step_function_inputs/CMIP245-winter-median-ta.json
@@ -1,10 +1,8 @@
-[
-    {
-        "collection": "CMIP245-winter-median-ta",
-        "prefix": "EIS/NEX-GDDP-CMIP6/",
-        "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)_tas(.*)ssp245(.*).cog.tif$",
-        "discovery": "s3",
-        "upload": false
-    }
-]
+{
+  "collection": "CMIP245-winter-median-ta",
+  "prefix": "EIS/NEX-GDDP-CMIP6/",
+  "bucket": "veda-data-store-staging",
+  "filename_regex": "^(.*)_tas(.*)ssp245(.*).cog.tif$",
+  "discovery": "s3",
+  "upload": false
+}

--- a/data/step_function_inputs/CMIP245-winter-median-ta.json
+++ b/data/step_function_inputs/CMIP245-winter-median-ta.json
@@ -1,0 +1,10 @@
+[
+    {
+        "collection": "CMIP245-winter-median-ta",
+        "prefix": "EIS/NEX-GDDP-CMIP6/",
+        "bucket": "veda-data-store-staging",
+        "filename_regex": "^(.*)winterTas(.*).tif$",
+        "discovery": "s3",
+        "upload": false
+    }
+]

--- a/data/step_function_inputs/CMIP585-winter-median-pr.json
+++ b/data/step_function_inputs/CMIP585-winter-median-pr.json
@@ -1,10 +1,8 @@
-[
-    {
-        "collection": "CMIP585-winter-median-pr",
-        "prefix": "EIS/NEX-GDDP-CMIP6/",
-        "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)_pr(.*)ssp585(.*).cog.tif$",
-        "discovery": "s3",
-        "upload": false
-    }
-]
+{
+  "collection": "CMIP585-winter-median-pr",
+  "prefix": "EIS/NEX-GDDP-CMIP6/",
+  "bucket": "veda-data-store-staging",
+  "filename_regex": "^(.*)_pr(.*)ssp585(.*).cog.tif$",
+  "discovery": "s3",
+  "upload": false
+}

--- a/data/step_function_inputs/CMIP585-winter-median-pr.json
+++ b/data/step_function_inputs/CMIP585-winter-median-pr.json
@@ -1,9 +1,9 @@
 [
     {
-        "collection": "CMIP245-winter-median-pr",
+        "collection": "CMIP585-winter-median-pr",
         "prefix": "EIS/NEX-GDDP-CMIP6/",
         "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)ssp245(.*)winter_pr(.*).cog.tif$",
+        "filename_regex": "^(.*)ssp585(.*)winter_pr(.*).cog.tif$",
         "discovery": "s3",
         "upload": false
     }

--- a/data/step_function_inputs/CMIP585-winter-median-pr.json
+++ b/data/step_function_inputs/CMIP585-winter-median-pr.json
@@ -3,7 +3,7 @@
         "collection": "CMIP585-winter-median-pr",
         "prefix": "EIS/NEX-GDDP-CMIP6/",
         "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)ssp585(.*)winter_pr(.*).cog.tif$",
+        "filename_regex": "^(.*)_pr(.*)ssp585(.*).cog.tif$",
         "discovery": "s3",
         "upload": false
     }

--- a/data/step_function_inputs/CMIP585-winter-median-ta.json
+++ b/data/step_function_inputs/CMIP585-winter-median-ta.json
@@ -1,10 +1,8 @@
-[
-    {
-        "collection": "CMIP585-winter-median-ta",
-        "prefix": "EIS/NEX-GDDP-CMIP6/",
-        "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)_tas(.*)ssp585(.*).cog.tif$",
-        "discovery": "s3",
-        "upload": false
-    }
-]
+{
+  "collection": "CMIP585-winter-median-ta",
+  "prefix": "EIS/NEX-GDDP-CMIP6/",
+  "bucket": "veda-data-store-staging",
+  "filename_regex": "^(.*)_tas(.*)ssp585(.*).cog.tif$",
+  "discovery": "s3",
+  "upload": false
+}

--- a/data/step_function_inputs/CMIP585-winter-median-ta.json
+++ b/data/step_function_inputs/CMIP585-winter-median-ta.json
@@ -1,9 +1,9 @@
 [
     {
-        "collection": "CMIP245-winter-median-pr",
+        "collection": "CMIP585-winter-median-ta",
         "prefix": "EIS/NEX-GDDP-CMIP6/",
         "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)ssp245(.*)winter_pr(.*).cog.tif$",
+        "filename_regex": "^(.*)ssp585(.*)winter_ta(.*).cog.tif$",
         "discovery": "s3",
         "upload": false
     }

--- a/data/step_function_inputs/CMIP585-winter-median-ta.json
+++ b/data/step_function_inputs/CMIP585-winter-median-ta.json
@@ -3,7 +3,7 @@
         "collection": "CMIP585-winter-median-ta",
         "prefix": "EIS/NEX-GDDP-CMIP6/",
         "bucket": "veda-data-store-staging",
-        "filename_regex": "^(.*)ssp585(.*)winter_ta(.*).cog.tif$",
+        "filename_regex": "^(.*)_tas(.*)ssp585(.*).cog.tif$",
         "discovery": "s3",
         "upload": false
     }


### PR DESCRIPTION
This pull includes post-processed 20-year projected changes to air temperature and precipitation from NEX-GDDP-CMIP6 (2 scenarios). These are added to support a discovery in-progress focused on the [EIS snow projections](https://github.com/NASA-IMPACT/veda-config/blob/develop/datasets/snow-projections-diff.data.mdx).