### PR TITLE
Remove undefined secret in workflow

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -17,5 +17,3 @@ jobs:
       vector_secret_name: ${{ secrets.vector_secret_name }}
       vector_vpc_id: ${{ secrets.vector_vpc_id }}
       vector_security_group: ${{ secrets.vector_security_group }}
-      oidc_role_arn: ${{ secrets.oidc_role_arn }}
-


### PR DESCRIPTION
Small bug got merged to `develop` in #312 - this secret isn't needed for our automated CI/CD at this time, but was left in the `deploy` workflow from earlier development