### PR TITLE
upgrade rio stac, include geom densify

### DIFF
--- a/lambdas/build-stac/requirements.txt
+++ b/lambdas/build-stac/requirements.txt
@@ -4,7 +4,7 @@ boto3
 pystac==1.4.0
 python-cmr
 rasterio==1.3.0
-rio-stac==0.4.2
+rio-stac==0.7.0
 shapely
 smart-open
 pydantic==1.9.1

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -45,6 +45,8 @@ def create_item(
                 asset_media_type
                 or "image/tiff; application=geotiff; profile=cloud-optimized"
             ),
+            geom_densify_pts=10,
+            geom_precision=5
         )
 
     rasterio_kwargs = {}


### PR DESCRIPTION
Related to https://github.com/NASA-IMPACT/veda-data-pipelines/issues/235 

Upgrade rio stac to deal with incorrect geom re-projection. 